### PR TITLE
Fix request body in lambda event

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -84,7 +84,7 @@ exports.onCreateDevServer = (
       httpMethod: req.method,
       queryStringParameters: req.query || {},
       headers: req.headers,
-      body: isBase64 ? base64.encode(req.body) : res.body,
+      body: isBase64 ? base64.encode(req.body) : req.body,
       isBase64Encoded: isBase64,
     };
 


### PR DESCRIPTION
Thanks for building this awesome plugin!  It's been really useful.  I noticed, as I was writing a function that takes a request body, that the request body is not available in the lambda event.  It was just a typo, grabbing the body from the `res` instead of the `req`.  😄 Took me a while of staring at it to figure out what was going on.