### PR TITLE
Grammar change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Directory of the source of functions
 
 (_required_, default: `undefined`)
 
-Directory where to put builded functions
+Directory where to put built functions
 
 ```javascript
 plugins: [


### PR DESCRIPTION
Change summary wording of what `functionsOutput` does. 

Built is the correct word as opposed to builded.